### PR TITLE
ci: workflowを厳格化

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,16 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Repository checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
 
       - name: Set up JDK 17


### PR DESCRIPTION
* permissions を絞る
* hosted runnerの種別を固定
* persist-credentials: false
